### PR TITLE
Feature: Add choice system for Fighting Styles, Fighter Strategies, Fighting Masteries

### DIFF
--- a/StarWars5e.Api/Controllers/FightingStrategyController.cs
+++ b/StarWars5e.Api/Controllers/FightingStrategyController.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
+using StarWars5e.Api.Storage;
+using StarWars5e.Models;
+using StarWars5e.Models.Enums;
+
+namespace StarWars5e.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class FightingStrategyController : ControllerBase
+    {
+        private readonly IAzureTableStorage _tableStorage;
+
+        public FightingStrategyController(IAzureTableStorage tableStorage)
+        {
+            _tableStorage = tableStorage;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<FightingStrategy>>> Get(Language language = Language.en)
+        {
+            List<FightingStrategy> FightingStrategy;
+            try
+            {
+                FightingStrategy = (await _tableStorage.GetAllAsync<FightingStrategy>($"fightingStrategies{language}")).ToList();
+            }
+            catch (StorageException e)
+            {
+                if (e.Message == "Not Found")
+                {
+                    FightingStrategy = (await _tableStorage.GetAllAsync<FightingStrategy>($"fightingStrategies{Language.en}")).ToList();
+                    return Ok(FightingStrategy);
+                }
+                throw;
+            }
+            return Ok(FightingStrategy);
+        }
+
+        //[HttpPost]
+        //public void Post([FromBody] Feat feat)
+        //{
+        //}
+
+        //[HttpDelete("{name}")]
+        //public void Delete(string name)
+        //{
+        //}
+    }
+}

--- a/StarWars5e.Api/Controllers/LanguagesController.cs
+++ b/StarWars5e.Api/Controllers/LanguagesController.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
+using StarWars5e.Api.Storage;
+using StarWars5e.Models;
+using StarWars5e.Models.Enums;
+
+namespace StarWars5e.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class LanguagesController : ControllerBase
+    {
+        private readonly IAzureTableStorage _tableStorage;
+
+        public LanguagesController(IAzureTableStorage tableStorage)
+        {
+            _tableStorage = tableStorage;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CommonLanguage>>> Get(Language language = Language.en)
+        {
+            List<CommonLanguage> languages;
+            try
+            {
+                languages = (await _tableStorage.GetAllAsync<CommonLanguage>($"languages{language}")).ToList();
+            }
+            catch (StorageException e)
+            {
+                if (e.Message == "Not Found")
+                {
+                    languages = (await _tableStorage.GetAllAsync<CommonLanguage>($"languages{Language.en}")).ToList();
+                    return Ok(languages);
+                }
+                throw;
+            }
+            return Ok(languages);
+        }
+    }
+}

--- a/StarWars5e.Api/Startup.cs
+++ b/StarWars5e.Api/Startup.cs
@@ -86,12 +86,13 @@ namespace StarWars5e.Api
                     });
             });
 
+            var searchEndpoint = Configuration["SearchEndpoint"] ?? "https://sw5esearch.search.windows.net";
             var tableStorage = new AzureTableStorage(Configuration["StorageAccountConnectionString"]);
             var cloudStorageAccount = CloudStorageAccount.Parse(Configuration["StorageAccountConnectionString"]);
             var cloudTableClient = cloudStorageAccount.CreateCloudTableClient();
             var cloudBlobClient = new BlobServiceClient(Configuration["StorageAccountConnectionString"]);
-            var searchIndexClient = new SearchIndexClient(new Uri("https://sw5esearch.search.windows.net"), new AzureKeyCredential(Configuration["SearchKey"]));
-            var searchClient = new SearchClient(new Uri("https://sw5esearch.search.windows.net"), "searchterms-index", new AzureKeyCredential(Configuration["SearchKey"]));
+            var searchIndexClient = new SearchIndexClient(new Uri(searchEndpoint), new AzureKeyCredential(Configuration["SearchKey"]));
+            var searchClient = new SearchClient(new Uri(searchEndpoint), "searchterms-index", new AzureKeyCredential(Configuration["SearchKey"]));
 
             services.AddSingleton<IAzureTableStorage>(tableStorage);
 

--- a/StarWars5e.Models/CommonLanguage.cs
+++ b/StarWars5e.Models/CommonLanguage.cs
@@ -1,0 +1,10 @@
+﻿namespace StarWars5e.Models
+{
+    public class CommonLanguage : BaseEntity
+    {
+        public string Name { get; set; }
+        public string Text { get; set; }
+        public string Metadata { get; set; }
+    }
+    
+}

--- a/StarWars5e.Models/Enums/GlobalSearchTermType.cs
+++ b/StarWars5e.Models/Enums/GlobalSearchTermType.cs
@@ -56,6 +56,7 @@
         SplashclassImprovement,
         WeaponFocus,
         WeaponSupremacy,
-        Maneuver
+        Maneuver,
+        FightingStrategy
     }
 }

--- a/StarWars5e.Models/Feat.cs
+++ b/StarWars5e.Models/Feat.cs
@@ -5,9 +5,11 @@ namespace StarWars5e.Models
 {
     public class Feat : BaseEntity
     {
+        public Feat() { }
         public string Name { get; set; }
         public string Prerequisite { get; set; }
         public string Text { get; set; }
+        public string Metadata { get; set; }
         public List<string> AttributesIncreased { get; set; }
         public string AttributesIncreasedJson
         {

--- a/StarWars5e.Models/FightingStrategy.cs
+++ b/StarWars5e.Models/FightingStrategy.cs
@@ -1,0 +1,9 @@
+﻿namespace StarWars5e.Models
+{
+    public class FightingStrategy : BaseEntity
+    {
+        public string Name { get; set; }
+        public string Text { get; set; }
+        public string Metadata { get; set; }
+    }
+}

--- a/StarWars5e.Models/Utils/StringExtentions.cs
+++ b/StarWars5e.Models/Utils/StringExtentions.cs
@@ -1,12 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace StarWars5e.Models.Utils
 {
     public static class StringExtentions
     {
+        public static string MinifyJson(this string json)
+        {
+            var options =
+                new JsonWriterOptions
+                {
+                    Indented = false,
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                };
+            using var document = JsonDocument.Parse(json);
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, options);
+            document.WriteTo(writer);
+            writer.Flush();
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
         public static bool HasLeadingHtmlWhitespace(this string input)
         {
             return input.Trim().StartsWith("&emsp;") || input.Trim().StartsWith("&nbsp;");

--- a/StarWars5e.Parser/Managers/PlayerHandbookManager.cs
+++ b/StarWars5e.Parser/Managers/PlayerHandbookManager.cs
@@ -512,7 +512,20 @@ namespace StarWars5e.Parser.Managers
                 Console.WriteLine("Failed to upload PHB armor properties.");
             }
 
+            try
+            {
+                var languages = await new PlayerHandbookLanguagesProcessor()
+                    .Process(_phbFilesNames.Where(p => p.Equals("PHB.phb_04.txt")).ToList(), _localization);
 
+                await _tableStorage.AddBatchAsync<CommonLanguage>($"languages{_localization.Language}", languages,
+                    new BatchOperationOptions { BatchInsertMethod = BatchInsertMethod.InsertOrReplace });
+            }
+            catch (StorageException)
+            {
+                Console.WriteLine("Failed to upload Common Languages.");
+            }
+
+            
             try
             {
                 var maneuvers =

--- a/StarWars5e.Parser/Managers/PlayerHandbookManager.cs
+++ b/StarWars5e.Parser/Managers/PlayerHandbookManager.cs
@@ -536,6 +536,30 @@ namespace StarWars5e.Parser.Managers
                 Console.WriteLine("Failed to upload PHB maneuvers.");
             }
 
+
+            try
+            {
+                var fightingStrategies =
+                    await new ExpandedContentFightingStrategiesProcessor(_localization).Process(_phbFilesNames.Where(p => p.Equals("PHB.phb_03.txt")).ToList(), _localization, ContentType.Core);
+
+                foreach (var strategy in fightingStrategies)
+                {
+                    strategy.ContentSourceEnum = ContentSource.PHB;
+
+                    var strategySearchTerm = _globalSearchTermRepository.CreateSearchTerm(strategy.Name,
+                        GlobalSearchTermType.FightingStrategy, ContentType.Core,
+                        $"/classes/fighter");
+                    _globalSearchTermRepository.SearchTerms.Add(strategySearchTerm);
+                }
+
+                await _tableStorage.AddBatchAsync<FightingStrategy>($"fightingStrategies{_localization.Language}", fightingStrategies,
+                    new BatchOperationOptions { BatchInsertMethod = BatchInsertMethod.InsertOrReplace });
+            }
+            catch (StorageException e)
+            {
+                Console.WriteLine("Failed to upload PHB fighting strategies.");
+            }
+
             foreach (var referenceName in ReferenceNames)
             {
                 var referenceSearchTerm = _globalSearchTermRepository.CreateSearchTerm(referenceName.name, referenceName.globalSearchTermType, ContentType.Core,

--- a/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
+++ b/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
@@ -55,7 +55,7 @@ namespace StarWars5e.Parser.Processors
                     ContentTypeEnum = contentType
                 };
 
-                strategy.Metadata = FeatureMetadataProcessor.ProcessMetadata(strategy);
+                strategy.Metadata = MetadataProcessor.ProcessMetadata(strategy);
                 strategy.Text = string.Join(Environment.NewLine, strategyLines.Skip(1));
 
                 return strategy;

--- a/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
+++ b/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
@@ -1,0 +1,68 @@
+﻿using StarWars5e.Models;
+using StarWars5e.Models.Enums;
+using StarWars5e.Models.Utils;
+using StarWars5e.Parser.Localization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StarWars5e.Parser.Processors
+{
+    public class ExpandedContentFightingStrategiesProcessor : BaseProcessor<FightingStrategy>
+    {
+        public ExpandedContentFightingStrategiesProcessor(ILocalization localization)
+        {
+            Localization = localization;
+        }
+
+        public override Task<List<FightingStrategy>> FindBlocks(List<string> lines, ContentType contentType)
+        {
+            var strategies = new List<FightingStrategy>();
+            lines = lines.CleanListOfStrings().ToList();
+            var strategyStartLines = lines.Where(f => f.StartsWith($"#### ") && f.EndsWith($"Strategist"));
+
+            foreach (var strategyStartLine in strategyStartLines)
+            {
+                var strategyStartIndex = lines.IndexOf(strategyStartLine);
+
+                var strategyEndIndex = lines.FindIndex(strategyStartIndex + 1, f => f.StartsWith("#"));
+                var strategyLines = lines.Skip(strategyStartIndex);
+
+                if (strategyEndIndex != -1)
+                {
+                    strategyLines = lines.Skip(strategyStartIndex).Take(strategyEndIndex - strategyStartIndex);
+                }
+
+                strategies.Add(ParseStrategy(strategyLines.CleanListOfStrings().ToList(), contentType));
+            }
+
+            return Task.FromResult(strategies);
+        }
+
+        public FightingStrategy ParseStrategy(List<string> strategyLines, ContentType contentType)
+        {
+            var name = strategyLines[0].Split("####")[1].Trim();
+
+            try
+            {
+                var strategy = new FightingStrategy
+                {
+                    RowKey = name.FormatKey(),
+                    Name = name,
+                    PartitionKey = contentType.ToString(),
+                    ContentTypeEnum = contentType
+                };
+
+                strategy.Text = string.Join(Environment.NewLine, strategyLines.Skip(1));
+
+                return strategy;
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed while parsing fighting strategy {name}", e);
+            }
+        }
+    }
+}

--- a/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
+++ b/StarWars5e.Parser/Processors/ExpandedContentFightingStrategiesProcessor.cs
@@ -55,6 +55,7 @@ namespace StarWars5e.Parser.Processors
                     ContentTypeEnum = contentType
                 };
 
+                strategy.Metadata = FeatureMetadataProcessor.ProcessMetadata(strategy);
                 strategy.Text = string.Join(Environment.NewLine, strategyLines.Skip(1));
 
                 return strategy;

--- a/StarWars5e.Parser/Processors/ExpandedContentSpeciesProcessor.cs
+++ b/StarWars5e.Parser/Processors/ExpandedContentSpeciesProcessor.cs
@@ -113,6 +113,7 @@ namespace StarWars5e.Parser.Processors
 
                 foreach (var speciesTrait in species.Traits)
                 {
+                    //var metadata = ReadMetadata($"features.{Enum.GetName(FeatureSource.Species)}.{name.Replace(" ", "")}.{speciesTrait.Name.Replace(" ", "")}");
                     var feature = new Feature
                     {
                         Name = speciesTrait.Name,
@@ -122,6 +123,7 @@ namespace StarWars5e.Parser.Processors
                         SourceEnum = FeatureSource.Species,
                         PartitionKey = contentType.ToString()
                     };
+                    feature.Metadata = FeatureMetadataProcessor.ProcessMetadata(feature);
                     species.Features.Add(feature);
                 }
 

--- a/StarWars5e.Parser/Processors/ExpandedContentSpeciesProcessor.cs
+++ b/StarWars5e.Parser/Processors/ExpandedContentSpeciesProcessor.cs
@@ -123,7 +123,7 @@ namespace StarWars5e.Parser.Processors
                         SourceEnum = FeatureSource.Species,
                         PartitionKey = contentType.ToString()
                     };
-                    feature.Metadata = FeatureMetadataProcessor.ProcessMetadata(feature);
+                    feature.Metadata = MetadataProcessor.ProcessMetadata(feature);
                     species.Features.Add(feature);
                 }
 

--- a/StarWars5e.Parser/Processors/FeatureMetadataProcessor.cs
+++ b/StarWars5e.Parser/Processors/FeatureMetadataProcessor.cs
@@ -1,0 +1,55 @@
+﻿using StarWars5e.Models;
+using StarWars5e.Models.Enums;
+using StarWars5e.Models.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StarWars5e.Parser.Processors
+{
+    internal static class FeatureMetadataProcessor
+    {
+
+        public static string ProcessMetadata(Feature feature)
+        {
+            var manifestStreams = Assembly.GetExecutingAssembly().GetManifestResourceNames();
+            var key = $"StarWars5e.Parser.Sources.metadata.features.{feature.Source}.{feature.SourceName.Replace(",", "").Replace(" ", "")}.{feature.Name.Replace(",", "").Replace(" ", "")}.json";
+            key = manifestStreams.FirstOrDefault(s => s.Equals(key, StringComparison.OrdinalIgnoreCase));
+            if (key == null) return String.Empty;
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(key))
+            {
+                if (stream == null)
+                {
+                    return String.Empty;
+                }
+                using (var reader = new StreamReader(stream, Encoding.UTF8, true, 128))
+                {
+                    return reader.ReadToEnd().MinifyJson();
+                }
+            }
+        }
+
+        public static string ProcessMetadata(FightingStrategy fightingStrategy)
+        {
+            var manifestStreams = Assembly.GetExecutingAssembly().GetManifestResourceNames();
+            var key = $"StarWars5e.Parser.Sources.metadata.FightingStrategy.{fightingStrategy.Name.Replace(",", "").Replace(" ", "")}.json";
+            key = manifestStreams.FirstOrDefault(s => s.Equals(key, StringComparison.OrdinalIgnoreCase));
+            if (key == null) return String.Empty;
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(key))
+            {
+                if (stream == null)
+                {
+                    return String.Empty;
+                }
+                using (var reader = new StreamReader(stream, Encoding.UTF8, true, 128))
+                {
+                    return reader.ReadToEnd().MinifyJson();
+                }
+            }
+        }
+    }
+}

--- a/StarWars5e.Parser/Processors/FeatureMetadataProcessor.cs
+++ b/StarWars5e.Parser/Processors/FeatureMetadataProcessor.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace StarWars5e.Parser.Processors
 {
-    internal static class FeatureMetadataProcessor
+    internal static class MetadataProcessor
     {
 
         public static string ProcessMetadata(Feature feature)
@@ -37,6 +37,25 @@ namespace StarWars5e.Parser.Processors
         {
             var manifestStreams = Assembly.GetExecutingAssembly().GetManifestResourceNames();
             var key = $"StarWars5e.Parser.Sources.metadata.FightingStrategy.{fightingStrategy.Name.Replace(",", "").Replace(" ", "")}.json";
+            key = manifestStreams.FirstOrDefault(s => s.Equals(key, StringComparison.OrdinalIgnoreCase));
+            if (key == null) return String.Empty;
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(key))
+            {
+                if (stream == null)
+                {
+                    return String.Empty;
+                }
+                using (var reader = new StreamReader(stream, Encoding.UTF8, true, 128))
+                {
+                    return reader.ReadToEnd().MinifyJson();
+                }
+            }
+        }
+
+        public static string ProcessMetadata(Feat feat)
+        {
+            var manifestStreams = Assembly.GetExecutingAssembly().GetManifestResourceNames();
+            var key = $"StarWars5e.Parser.Sources.metadata.Feats.{feat.Name.Replace(",", "").Replace(" ", "")}.json";
             key = manifestStreams.FirstOrDefault(s => s.Equals(key, StringComparison.OrdinalIgnoreCase));
             if (key == null) return String.Empty;
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(key))

--- a/StarWars5e.Parser/Processors/PHB/PlayerHandbookClassProcessor.cs
+++ b/StarWars5e.Parser/Processors/PHB/PlayerHandbookClassProcessor.cs
@@ -408,7 +408,7 @@ namespace StarWars5e.Parser.Processors.PHB
                         .Take(nextFeatureNameLineIndex - currentFeatureNameLineIndex).RemoveEmptyLines().ToList();
 
                 var name = featureLines[0].Split("# ")[1].Trim();
-                
+                //var metadata = ReadMetadata($"features.{Enum.GetName(featureSource)}.{sourceName.Replace(" ", "")}.{name.Replace(" ", "")}");
 
                 var levels = GetFeatureLevels(featureLines.Skip(1).CleanListOfStrings().ToList());
 
@@ -425,7 +425,7 @@ namespace StarWars5e.Parser.Processors.PHB
                         RowKey = $"{featureSource}-{sourceName}-{name}-{level}".Replace("/", string.Empty)
                             .Replace(@"\", string.Empty)
                     };
-
+                    feature.Metadata = FeatureMetadataProcessor.ProcessMetadata(feature);
                     features.Add(feature);
                 }
             }

--- a/StarWars5e.Parser/Processors/PHB/PlayerHandbookClassProcessor.cs
+++ b/StarWars5e.Parser/Processors/PHB/PlayerHandbookClassProcessor.cs
@@ -425,7 +425,7 @@ namespace StarWars5e.Parser.Processors.PHB
                         RowKey = $"{featureSource}-{sourceName}-{name}-{level}".Replace("/", string.Empty)
                             .Replace(@"\", string.Empty)
                     };
-                    feature.Metadata = FeatureMetadataProcessor.ProcessMetadata(feature);
+                    feature.Metadata = MetadataProcessor.ProcessMetadata(feature);
                     features.Add(feature);
                 }
             }

--- a/StarWars5e.Parser/Processors/PHB/PlayerHandbookFeatProcessor.cs
+++ b/StarWars5e.Parser/Processors/PHB/PlayerHandbookFeatProcessor.cs
@@ -57,6 +57,8 @@ namespace StarWars5e.Parser.Processors.PHB
                     PartitionKey = contentType.ToString(),
                     RowKey = name
                 };
+                
+                feat.Metadata = MetadataProcessor.ProcessMetadata(feat);
 
                 var prerequisiteIndex =
                     featLines.FindIndex(f =>

--- a/StarWars5e.Parser/Processors/PHB/PlayerHandbookLanguagesProcessor.cs
+++ b/StarWars5e.Parser/Processors/PHB/PlayerHandbookLanguagesProcessor.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using StarWars5e.Models;
+using StarWars5e.Models.Enums;
+using StarWars5e.Models.Utils;
+
+namespace StarWars5e.Parser.Processors.PHB
+{
+    public class PlayerHandbookLanguagesProcessor : BaseProcessor<CommonLanguage>
+    {
+        public override Task<List<CommonLanguage>> FindBlocks(List<string> lines)
+        {
+            var languages = new List<CommonLanguage>();
+
+            var languagesStart = lines.FindIndex(x => x.StartsWith("##### Common Languages"));
+            var languagesEnd = lines.FindIndex(languagesStart + 1, x => x.StartsWith("#"));
+
+            languages.AddRange(lines
+                .GetRange(languagesStart, languagesEnd - languagesStart)
+                .Where(l => l.StartsWith("|") && !l.StartsWith("||") && !l.StartsWith("|:"))
+                .Select(l => new CommonLanguage()
+                {
+                    Name = l.Split("|")[1].Trim(),
+                    RowKey = l.Split("|")[1].Trim(),
+                    PartitionKey = "Core"
+                }));
+
+            return Task.FromResult(languages);
+        }
+    }
+}

--- a/StarWars5e.Parser/Program.cs
+++ b/StarWars5e.Parser/Program.cs
@@ -62,9 +62,10 @@ namespace StarWars5e.Parser
 
             if (!string.IsNullOrWhiteSpace(config["SearchKey"]))
             {
-                var searchIndexClient = new SearchIndexClient(new Uri("https://sw5esearch.search.windows.net"),
+                var searchEndpoint = config["SearchEndpoint"] ?? "https://sw5esearch.search.windows.net";
+                var searchIndexClient = new SearchIndexClient(new Uri(searchEndpoint),
                     new AzureKeyCredential(config["SearchKey"]));
-                var searchIndexerClient = new SearchIndexerClient(new Uri("https://sw5esearch.search.windows.net"),
+                var searchIndexerClient = new SearchIndexerClient(new Uri(searchEndpoint),
                     new AzureKeyCredential(config["SearchKey"]));
 
                 serviceProvider.AddSingleton(searchIndexClient);

--- a/StarWars5e.Parser/Sources/en/PHB/phb_04.txt
+++ b/StarWars5e.Parser/Sources/en/PHB/phb_04.txt
@@ -109,6 +109,7 @@ A list of the most commonly spoken languages of *Star Wars* can be found below i
 |   Tusken  |
 |	Twi'leki	|
 |	Zabraki	|
+|	Kaminoan |
 
 </div>
 

--- a/StarWars5e.Parser/Sources/metadata/Feats/FightingMaster.json
+++ b/StarWars5e.Parser/Sources/metadata/Feats/FightingMaster.json
@@ -1,0 +1,3 @@
+{
+  "fightingMastery":  1
+}

--- a/StarWars5e.Parser/Sources/metadata/Feats/FightingStylist.json
+++ b/StarWars5e.Parser/Sources/metadata/Feats/FightingStylist.json
@@ -1,0 +1,3 @@
+{
+  "fightingStyle":  1
+}

--- a/StarWars5e.Parser/Sources/metadata/Features/Archetype/TacticalSpecialist/BonusProficiencies.json
+++ b/StarWars5e.Parser/Sources/metadata/Features/Archetype/TacticalSpecialist/BonusProficiencies.json
@@ -1,0 +1,5 @@
+{
+  "bonusProficiency": {
+    "type": "Tool"
+  }
+}

--- a/StarWars5e.Parser/Sources/metadata/Features/Class/Fighter/FighterStrategies.json
+++ b/StarWars5e.Parser/Sources/metadata/Features/Class/Fighter/FighterStrategies.json
@@ -1,0 +1,3 @@
+{
+  "fightingStrategy": 1
+}

--- a/StarWars5e.Parser/Sources/metadata/Features/Class/Fighter/FightingStyle.json
+++ b/StarWars5e.Parser/Sources/metadata/Features/Class/Fighter/FightingStyle.json
@@ -1,0 +1,3 @@
+{
+  "fightingStyle":  1
+}

--- a/StarWars5e.Parser/Sources/metadata/FightingStrategy/MasteryStrategist.json
+++ b/StarWars5e.Parser/Sources/metadata/FightingStrategy/MasteryStrategist.json
@@ -1,0 +1,3 @@
+{
+  "fightingMastery":  1
+}

--- a/StarWars5e.Parser/Sources/metadata/FightingStrategy/StyleStrategist.json
+++ b/StarWars5e.Parser/Sources/metadata/FightingStrategy/StyleStrategist.json
@@ -1,0 +1,3 @@
+{
+  "fightingStyle": 1
+}

--- a/StarWars5e.Parser/StarWars5e.Parser.csproj
+++ b/StarWars5e.Parser/StarWars5e.Parser.csproj
@@ -492,6 +492,11 @@
     <EmbeddedResource Include="Sources\sp\WH\wh_aa.txt" />
     <EmbeddedResource Include="Sources\sp\WH\wh_changelog.txt" />
   </ItemGroup>
+	<Target Name="EmbedMetadata" BeforeTargets="BeforeBuild">
+		<CreateItem Include="Sources\metadata\**\*.json">
+			<Output ItemName="EmbeddedResource" TaskParameter="Include" />
+		</CreateItem>
+	</Target>
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.0.2" />


### PR DESCRIPTION
Added system to Parser to allow metadata to be configured for Feat/Features/FighterStrategies and merged in during the parsing from source material. 

To modify metadata on features see `./StarWars5e.Parser/sources/metadata/features/class/fighter/FightingStyles.json` 
To modify metadata on feats see `./StarWars5e.Parser/sources/metadata/feat/FightingStylist.json` 
To modify metadata on fighter strategies see `./StarWars5e.Parser/sources/metadata/FighterStrategies/MasteryStrategy.json` 

